### PR TITLE
Riot api roles

### DIFF
--- a/lib/lol_buddy/player_server/player_server.ex
+++ b/lib/lol_buddy/player_server/player_server.ex
@@ -1,4 +1,7 @@
 defmodule LolBuddy.PlayerServer do
+  @moduledoc """
+  Simple GenServer for storing Players.
+  """
   use GenServer
   alias LolBuddy.Players.Player
 

--- a/lib/lol_buddy/player_server/region_mapper.ex
+++ b/lib/lol_buddy/player_server/region_mapper.ex
@@ -1,4 +1,11 @@
 defmodule LolBuddy.PlayerServer.RegionMapper do
+  @moduledoc """
+  The interface from which access to PlayerServers should be handled.
+  Since players are stored in PlayerServers separated by region, this
+  module unifies the access by mapping functions on PlayerServers to the correct
+  PlayerServer, based on the given Player's region.
+  """
+
   alias LolBuddy.Players.Player
   alias LolBuddy.PlayerServer
 

--- a/lib/lol_buddy/player_server/supervisor.ex
+++ b/lib/lol_buddy/player_server/supervisor.ex
@@ -1,4 +1,10 @@
 defmodule LolBuddy.PlayerServer.Supervisor do
+  @moduledoc """
+  The Supervisor responsible for the PlayerServers spawned for each region.
+  Failures are handled individually on each PlayerServer and thereby only results
+  in restarts of the single failing instance.
+  """
+
   use Supervisor
   alias LolBuddy.PlayerServer
 

--- a/lib/lol_buddy/players/criteria.ex
+++ b/lib/lol_buddy/players/criteria.ex
@@ -1,4 +1,8 @@
 defmodule LolBuddy.Players.Criteria do
+  @moduledoc """
+  Struct definining the possible criterias with which Players can
+  filter their matches.
+  """
   alias LolBuddy.Players.Player
   defstruct positions: [], voice: false, age_groups: []
 

--- a/lib/lol_buddy/players/matching.ex
+++ b/lib/lol_buddy/players/matching.ex
@@ -1,10 +1,15 @@
 defmodule LolBuddy.Players.Matching do
+  @moduledoc """
+  Module containing all logic for matching players with other players.
+  This included handling whether or not they can play with eachother based on Riot's
+  own rules on the matter: 
+    https://support.riotgames.com/hc/en-us/articles/204010760-Ranked-Play-FAQ
+  and whether Players criterias' are mutually compatible.
+  """
   alias LolBuddy.Players.Player
   alias LolBuddy.Players.Criteria
   
   @loose_tiers ["BRONZE", "SILVER", "GOLD", "PLATINUM"]
-  # resource for who can play with who
-  # https://support.riotgames.com/hc/en-us/articles/204010760-Ranked-Play-FAQ
 
   @doc """
   Returns a boolean representing whether Player 'player' and Player 'candidate'

--- a/lib/lol_buddy/riot_api/champions.ex
+++ b/lib/lol_buddy/riot_api/champions.ex
@@ -1,5 +1,8 @@
 defmodule LolBuddy.RiotApi.Champions do
-
+  @moduledoc """
+  A manually maintained list of champion names from champion id.
+  Primarily to save calls to Riot's Api and thereby reduce latency.
+  """
     
     @champions  [%{
         "id": 24,

--- a/lib/lol_buddy/riot_api/positions.ex
+++ b/lib/lol_buddy/riot_api/positions.ex
@@ -1,4 +1,10 @@
 defmodule LolBuddy.RiotApi.Positions do
+  @moduledoc """
+  Module for deducing positions from a list of champions.
+  This is done through a manually maintained list of most likely played positions
+  for each champion.
+  """
+
   @always 3
   @mainly 2
   @rarely 1

--- a/lib/lol_buddy/riot_api/regions.ex
+++ b/lib/lol_buddy/riot_api/regions.ex
@@ -1,4 +1,9 @@
 defmodule LolBuddy.RiotApi.Regions do
+  @moduledoc """
+  Contains the the list of rigions as well as the addresses for all of their endpoints.
+  These can be found here:
+  https://developer.riotgames.com/regional-endpoints.html
+  """
   @type region :: :br | :eune | :euw | :jp | :kr | :lan | :las | :na | :oce | :tr | :ru | :pbe
   @regions %{
     br: "https://br1.api.riotgames.com",

--- a/lib/lol_buddy/riot_api/riot_api.ex
+++ b/lib/lol_buddy/riot_api/riot_api.ex
@@ -1,7 +1,7 @@
 defmodule LolBuddy.RiotApi.Api do
   @moduledoc """
   This module handles all interaction with Riot's Developer Api.
-  It is expected to me accessed through 'LolBuddy.RiotApi.Api.fetch_summoner_info/2',
+  It is expected to be accessed through 'LolBuddy.RiotApi.Api.fetch_summoner_info/2',
   although several other functions are public, primarily for the sake of testing.
   """
 

--- a/lib/lol_buddy/riot_api/riot_api.ex
+++ b/lib/lol_buddy/riot_api/riot_api.ex
@@ -174,7 +174,7 @@ defmodule LolBuddy.RiotApi.Api do
     end
   end
 
-  def extract_most_played_role(matches, amount \\ 2) do
+  def extract_most_played_roles(matches, amount \\ 2) do
     matches
     |> Enum.map(fn match -> role_from_match(match) end)
     |> extract_most_frequent(amount)

--- a/test/riot_api/riot_api_test.exs
+++ b/test/riot_api/riot_api_test.exs
@@ -74,21 +74,52 @@ defmodule LolBuddyRiotApi.ApiTest do
        %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played_role(matches, 2)
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_roles(matches, 2)
     assert Enum.count(most_played) == 1
     assert Enum.member?(most_played, :support)
   end
 
   test "correct most played role is extracted from a match list" do
     matches =
-      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played_role(matches, 2)
-    assert Enum.count(most_played) == 1
-    assert Enum.member?(most_played, :support)
+      [%{"lane" => "TOP", "role" => "SOLO"},
+       %{"lane" => "TOP", "role" => "SOLO"},
+       %{"lane" => "TOP", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "JUNGLE", "role" => "NONE"},
+       %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"lane" => "BOTTOM", "role" => "DUO_CARRY"},
+       %{"lane" => "BOTTOM", "role" => "DUO"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_roles(matches, 2)
+    assert Enum.count(most_played) == 2
+    assert Enum.member?(most_played, :top)
+    assert Enum.member?(most_played, :mid)
   end
 
+  test "correct amount of roles extracted with 5-way draw" do
+    matches =
+      [%{"lane" => "TOP", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "JUNGLE", "role" => "NONE"},
+       %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"lane" => "BOTTOM", "role" => "DUO_CARRY"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_roles(matches, 2)
+    assert Enum.count(most_played) == 2
+  end
 
+  test "test with draw for second role but clear winner for first" do
+    matches =
+      [%{"lane" => "TOP", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "MID", "role" => "SOLO"},
+       %{"lane" => "JUNGLE", "role" => "NONE"},
+       %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"lane" => "BOTTOM", "role" => "DUO_CARRY"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_roles(matches, 2)
+    assert Enum.count(most_played) == 2
+    assert Enum.member?(most_played, :mid)
+  end
 end

--- a/test/riot_api/riot_api_test.exs
+++ b/test/riot_api/riot_api_test.exs
@@ -11,7 +11,7 @@ defmodule LolBuddyRiotApi.ApiTest do
        %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played(matches)
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches)
     assert Enum.member?(most_played, "Jax")
     assert Enum.member?(most_played, "Sona")
     assert Enum.member?(most_played, "Tristana")
@@ -24,7 +24,7 @@ defmodule LolBuddyRiotApi.ApiTest do
        %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played(matches)
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches)
     assert Enum.count(most_played) == 3
   end
 
@@ -33,7 +33,7 @@ defmodule LolBuddyRiotApi.ApiTest do
       [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
        %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played(matches)
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches)
     assert Enum.member?(most_played, "Jax")
     assert Enum.count(most_played) == 1
   end

--- a/test/riot_api/riot_api_test.exs
+++ b/test/riot_api/riot_api_test.exs
@@ -4,37 +4,91 @@ defmodule LolBuddyRiotApi.ApiTest do
 
   test "correct champions are extracted from matches" do
     matches =
-      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches)
+      [%{"champion" => 24},
+       %{"champion" => 24},
+       %{"champion" => 37},
+       %{"champion" => 37},
+       %{"champion" => 18},
+       %{"champion" => 18},
+       %{"champion" => 27}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches, 3)
     assert Enum.member?(most_played, "Jax")
     assert Enum.member?(most_played, "Sona")
     assert Enum.member?(most_played, "Tristana")
     assert Enum.count(most_played) == 3
   end
 
-  test "draws still return at most 3 champions" do
+  test "champion draws still return at most 3 champions" do
     matches =
-      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches)
+      [%{"champion" => 24},
+       %{"champion" => 37},
+       %{"champion" => 18},
+       %{"champion" => 27}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches, 3)
     assert Enum.count(most_played) == 3
   end
 
   test "less than 3 champions in matches still finds most played" do
     matches =
-      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
-       %{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
-    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches)
+      [%{"champion" => 24},
+       %{"champion" => 24},
+       %{"champion" => 24}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_champions(matches, 3)
     assert Enum.member?(most_played, "Jax")
     assert Enum.count(most_played) == 1
   end
+
+  test "correct role is extracted from a match, top" do
+    match = %{"lane" => "TOP", "role" => "SOLO"}
+    assert LolBuddy.RiotApi.Api.role_from_match(match) == :top
+  end
+
+  test "correct role is extracted from a match, jungle" do
+    match = %{"lane" => "JUNGLE", "role" => "NONE"}
+    assert LolBuddy.RiotApi.Api.role_from_match(match) == :jungle
+  end
+
+  test "correct role is extracted from a match, mid" do
+    match = %{"lane" => "MID", "role" => "SOLO"}
+    assert LolBuddy.RiotApi.Api.role_from_match(match) == :mid
+  end
+
+  test "correct role is extracted from a match, marksman" do
+    match = %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_CARRY"}
+    assert LolBuddy.RiotApi.Api.role_from_match(match) == :marksman
+  end
+
+  test "correct role is extracted from a match, duo case" do
+    match = %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO"}
+    assert LolBuddy.RiotApi.Api.role_from_match(match) == :support
+  end
+
+  test "correct role is extracted from a match, support" do
+    match = %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}
+    assert LolBuddy.RiotApi.Api.role_from_match(match) == :support
+  end
+
+  test "correct most played role is extracted from a match list, single role" do
+    matches =
+      [%{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_role(matches, 2)
+    assert Enum.count(most_played) == 1
+    assert Enum.member?(most_played, :support)
+  end
+
+  test "correct most played role is extracted from a match list" do
+    matches =
+      [%{"champion" => 24, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 37, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 18, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"},
+       %{"champion" => 27, "lane" => "BOTTOM", "role" => "DUO_SUPPORT"}]
+    most_played = LolBuddy.RiotApi.Api.extract_most_played_role(matches, 2)
+    assert Enum.count(most_played) == 1
+    assert Enum.member?(most_played, :support)
+  end
+
+
 end


### PR DESCRIPTION
Implemented role deduction based on Riot's lane/role combination. This may perform more accurately than own deductions, or at the very least require less updating. Added a fair bit of documentation to a couple of the less documented leaves of the codebase. This merge also renders the 'LolBuddy.RiotApi.Positions module redundant, as well as the code relying on it in 'LolBuddy.RiotApi.Api'. Left it in for now while we see whether this performs as expected and yields more accurate results.